### PR TITLE
replacing the deprecated crypto.createCredentials() with tls.createSecureContext()

### DIFF
--- a/lib/core/layer.js
+++ b/lib/core/layer.js
@@ -34,7 +34,7 @@ function BufferLayer(socket) {
 	//for ssl connection
 	this.securePair = null;
 	this.socket = socket;
-	
+
 	var self = this;
 	// bind event
 	this.socket.on('data', function(data) {
@@ -50,7 +50,7 @@ function BufferLayer(socket) {
 	}).on('error', function (err) {
 		self.emit('error', err);
 	});
-	
+
 	//buffer data
 	this.buffers = [];
 	this.bufferLength = 0;
@@ -67,17 +67,17 @@ inherits(BufferLayer, events.EventEmitter);
 BufferLayer.prototype.recv = function(data) {
 	this.buffers[this.buffers.length] = data;
 	this.bufferLength += data.length;
-	
+
 	while(this.bufferLength >= this.expectedSize) {
 		//linear buffer
 		var expectedData = new type.Stream(this.expectedSize);
-		
+
 		//create expected data
 		while(expectedData.availableLength() > 0) {
-			
+
 			var rest = expectedData.availableLength();
 			var buffer = this.buffers.shift();
-			
+
 			if(buffer.length > expectedData.availableLength()) {
 				this.buffers.unshift(buffer.slice(rest));
 				new type.BinaryString(buffer, { readLength : new type.CallableValue(expectedData.availableLength()) }).write(expectedData);
@@ -86,7 +86,7 @@ BufferLayer.prototype.recv = function(data) {
 				new type.BinaryString(buffer).write(expectedData);
 			}
 		}
-		
+
 		this.bufferLength -= this.expectedSize;
 		expectedData.offset = 0;
 		this.emit('data', expectedData);
@@ -124,14 +124,14 @@ BufferLayer.prototype.expect = function(expectedSize) {
 BufferLayer.prototype.startTLS = function(callback) {
 	var options = {
 			socket : this.socket,
-			pair : tls.createSecurePair(crypto.createCredentials(), false, false, false)
+			pair : tls.createSecurePair(tls.createSecureContext(), false, false, false)
 	};
 	var self = this;
 	this.securePair = starttls(options, function(err) {
 		log.warn(err);
 		callback();
 	})
-	
+
 	this.securePair.cleartext.on('data', function(data) {
 		try {
 			self.recv(data);
@@ -149,12 +149,12 @@ BufferLayer.prototype.startTLS = function(callback) {
  * Convert connection to TLS server
  * @param keyFilePath	{string} key file path
  * @param crtFilePath	{string} certificat file path
- * @param callback	{function} 
+ * @param callback	{function}
  */
 BufferLayer.prototype.listenTLS = function(keyFilePath, crtFilePath, callback) {
 	var options = {
 			socket : this.socket,
-			pair : tls.createSecurePair(crypto.createCredentials({
+			pair : tls.createSecurePair(tls.createSecureContext({
 				key: fs.readFileSync(keyFilePath),
 				cert: fs.readFileSync(crtFilePath),
 			}), true, false, false)
@@ -165,7 +165,7 @@ BufferLayer.prototype.listenTLS = function(keyFilePath, crtFilePath, callback) {
 		self.cleartext = this.cleartext;
 		callback();
 	});
-	
+
 	this.securePair.cleartext.on('data', function(data) {
 		try {
 			self.recv(data);


### PR DESCRIPTION
[Node API docs noting that createCredential is deprecated](https://nodejs.org/api/crypto.html#crypto_crypto_createcredentials_details)

It was replaced with tls.createSecureContext().